### PR TITLE
Change the port the node server listens to

### DIFF
--- a/Test/.gulp/tasks/gt-browserSync.js
+++ b/Test/.gulp/tasks/gt-browserSync.js
@@ -2,7 +2,7 @@ const browserSync = require('browser-sync');
 
 module.exports = () => {
     browserSync.init(null, {
-        proxy: 'http://localhost:3000/',
+        proxy: 'http://localhost:8080/',
         files: ['www/**/*.*'],
         browser: 'google chrome'
     });

--- a/Test/app/server.js
+++ b/Test/app/server.js
@@ -16,5 +16,5 @@ app.get('/', (req, res) => {
     res.render('index');
 });
 
-// Listen at port 3000
-app.listen(3000);
+// Listen at port 8080
+app.listen(8080);


### PR DESCRIPTION
When the application is booted, BrowserSync proxies the server, using
port 3000 to serve the proxied site. The node server also starts up on
poort 3000, so the node server throws an error:

```Error: listen EADDRINUSE :::3000```

Changing the node server port to use something else (8080 in this
case) avoids this conflict. The BrowserSync config is updated to match.